### PR TITLE
fix: make master compile again after the pallet audit

### DIFF
--- a/bin/runtime/src/evm/mod.rs
+++ b/bin/runtime/src/evm/mod.rs
@@ -3,29 +3,30 @@
 mod precompiles;
 
 use crate::{
-	Aura, Balances, DynamicEvmBaseFee, Runtime, RuntimeEvent, Timestamp,
-	NORMAL_DISPATCH_RATIO
+	Aura, Balances, DynamicEvmBaseFee, EnsureThreeFifthsCouncil, Runtime, RuntimeEvent, Timestamp,
+	DAYS, NORMAL_DISPATCH_RATIO
 };
 
 use parity_scale_codec::Encode;
 use pallet_transaction_payment::Multiplier;
 use sp_core::{Get, H160, U256};
 use sp_runtime::{
-	ConsensusEngineId, Perquintill,
+	ConsensusEngineId, FixedPointNumber, Perquintill,
 };
 use sp_std::prelude::*;
 
 use frame_support::{
 	parameter_types,
-	traits::{ConstU32, ConstU64, FindAuthor},
+	traits::{ConstU32, ConstU64, EitherOfDiverse, FindAuthor},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
+use frame_system::EnsureRoot;
 use pallet_ethereum::PostLogContent;
 // use pallet_evm::{EnsureAccountId20, IdentityAddressMapping};
 
 use precompiles::FrontierPrecompiles;
 use primitives::{
-	TOKEN, AccountId, Balance, BlakeTwo256,
+	TOKEN, AccountId, Balance, BlakeTwo256, BlockNumber as SelendraBlockNumber,
 	evm::HashedDefaultMappings,
 };
 
@@ -119,6 +120,7 @@ impl pallet_ethereum::Config for Runtime {
 
 parameter_types! {
 	pub const AccountMappingStorageFee: Balance = TOKEN / 100; // 0.01 SEL storage fee
+	pub const RemapDelay: SelendraBlockNumber = 7 * DAYS;
 }
 
 impl pallet_unified_accounts::Config for Runtime {
@@ -128,6 +130,8 @@ impl pallet_unified_accounts::Config for Runtime {
 	type ChainId = ChainId;
 	type AccountMappingStorageFee = AccountMappingStorageFee;
 	type WeightInfo = pallet_unified_accounts::weights::SubstrateWeight<Runtime>;
+	type RemapOrigin = EitherOfDiverse<EnsureRoot<AccountId>, EnsureThreeFifthsCouncil>;
+	type RemapDelay = RemapDelay;
 }
 
 parameter_types! {
@@ -135,6 +139,8 @@ parameter_types! {
 	pub MinBaseFeePerGas: U256 = U256::from(100_000_000_u128);
 	pub MaxBaseFeePerGas: U256 = U256::from(10_000_000_000_000_u128);
 	pub StepLimitRatio: Perquintill = Perquintill::from_rational(93_u128, 1_000_000);
+	// pallet_transaction_payment MaximumMultiplier is Bounded::max_value(), so cap it here
+	pub MaxAdjustmentFactor: Multiplier = Multiplier::saturating_from_integer(10);
 }
 
 /// Simple wrapper for fetching current native transaction fee weight fee multiplier.
@@ -151,6 +157,7 @@ impl pallet_dynamic_evm_base_fee::Config for Runtime {
 	type MinBaseFeePerGas = MinBaseFeePerGas;
 	type MaxBaseFeePerGas = MaxBaseFeePerGas;
 	type AdjustmentFactor = AdjustmentFactorGetter;
+	type MaxAdjustmentFactor = MaxAdjustmentFactor;
 	type WeightFactor = ();
 	type StepLimitRatio = StepLimitRatio;
 	type WeightInfo = pallet_dynamic_evm_base_fee::weights::SubstrateWeight<Runtime>;

--- a/pallets/dynamic-evm-base-fee/src/mock.rs
+++ b/pallets/dynamic-evm-base-fee/src/mock.rs
@@ -30,7 +30,7 @@ use parity_scale_codec::Encode;
 use sp_core::H256;
 use sp_io::TestExternalities;
 use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup, One},
+	traits::{BlakeTwo256, Bounded, IdentityLookup, One},
 	BuildStorage, FixedU128, Perquintill,
 };
 
@@ -67,6 +67,12 @@ impl frame_system::Config for TestRuntime {
 	type OnSetCode = ();
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 	type RuntimeTask = RuntimeTask;
+	type ExtensionsWeightInfo = ();
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
 }
 
 impl pallet_balances::Config for TestRuntime {
@@ -82,8 +88,8 @@ impl pallet_balances::Config for TestRuntime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type FreezeIdentifier = ();
-	type MaxHolds = ConstU32<0>;
 	type MaxFreezes = ConstU32<0>;
+	type DoneSlashHandler = ();
 }
 
 impl pallet_timestamp::Config for TestRuntime {
@@ -106,6 +112,7 @@ impl pallet_dynamic_evm_base_fee::Config for TestRuntime {
 	type MinBaseFeePerGas = MinBaseFeePerGas;
 	type MaxBaseFeePerGas = MaxBaseFeePerGas;
 	type AdjustmentFactor = GetAdjustmentFactor;
+	type MaxAdjustmentFactor = GetMaxAdjustmentFactor;
 	type WeightFactor = ConstU128<30_000_000_000_000_000>;
 	type StepLimitRatio = StepLimitRation;
 	type WeightInfo = ();
@@ -123,16 +130,29 @@ construct_runtime!(
 );
 
 const ADJUSTMENT_FACTOR: &[u8] = b":adj_factor_evm";
+const MAX_ADJUSTMENT_FACTOR: &[u8] = b":max_adj_factor_evm";
 
 /// Helper method to set the adjustment factor used by the pallet.
 pub fn set_adjustment_factor(factor: FixedU128) {
 	storage::unhashed::put_raw(&ADJUSTMENT_FACTOR, &factor.encode());
 }
 
+/// Helper method to set the upper bound applied to the adjustment factor.
+pub fn set_max_adjustment_factor(factor: FixedU128) {
+	storage::unhashed::put_raw(&MAX_ADJUSTMENT_FACTOR, &factor.encode());
+}
+
 pub struct GetAdjustmentFactor;
 impl Get<FixedU128> for GetAdjustmentFactor {
 	fn get() -> FixedU128 {
 		storage::unhashed::get::<FixedU128>(&ADJUSTMENT_FACTOR).unwrap_or_default()
+	}
+}
+
+pub struct GetMaxAdjustmentFactor;
+impl Get<FixedU128> for GetMaxAdjustmentFactor {
+	fn get() -> FixedU128 {
+		storage::unhashed::get::<FixedU128>(&MAX_ADJUSTMENT_FACTOR).unwrap_or(FixedU128::max_value())
 	}
 }
 

--- a/pallets/dynamic-evm-base-fee/src/tests.rs
+++ b/pallets/dynamic-evm-base-fee/src/tests.rs
@@ -174,6 +174,31 @@ fn bfpg_bounds_are_respected() {
 }
 
 #[test]
+fn max_adjustment_factor_caps_the_ideal_value() {
+	ExtBuilder::build().execute_with(|| {
+		let init_bfpg = BaseFeePerGas::<TestRuntime>::get();
+
+		// Uncapped by default, so an extreme adjustment factor drives bfpg up.
+		set_adjustment_factor(FixedU128::max_value());
+		DynamicEvmBaseFee::on_finalize(1);
+		assert!(
+			BaseFeePerGas::<TestRuntime>::get() > init_bfpg,
+			"Sanity check: without a cap the fee rises."
+		);
+
+		// Same adjustment factor, but capped low enough that the ideal value lands
+		// below the current bfpg, so the fee has to move the other way.
+		BaseFeePerGas::<TestRuntime>::set(init_bfpg);
+		set_max_adjustment_factor(FixedU128::from_rational(1, 100));
+		DynamicEvmBaseFee::on_finalize(2);
+		assert!(
+			BaseFeePerGas::<TestRuntime>::get() < init_bfpg,
+			"MaxAdjustmentFactor must bound the adjustment factor used in the formula."
+		);
+	});
+}
+
+#[test]
 fn step_limit_ratio_is_respected() {
 	ExtBuilder::build().execute_with(|| {
 		// Lower bound, high adjustment factor


### PR DESCRIPTION
`master` has not compiled since 17 Apr. Commit 44e93d8 ("fix(security): all remaining pallet audit findings") added three associated types to two in-repo pallets and never updated the runtime's `impl` blocks:

| Pallet | Added | Runtime impl |
|---|---|---|
| `pallet-unified-accounts` | `RemapOrigin`, `RemapDelay` | not updated |
| `pallet-dynamic-evm-base-fee` | `MaxAdjustmentFactor` | not updated |

This is why `selendra/selendra:latest` on Docker Hub is still the v2.0.2 build from May 2025. The Docker workflow ran on `main` until #116 pointed it at `master`; the first run after that merge got as far as `Compiling selendra-runtime` and died on these three `E0046`s.

## Values I picked, and why

These two need sign-off, since they are governance parameters rather than mechanical fixes.

**`RemapOrigin = EitherOfDiverse<EnsureRoot<AccountId>, EnsureThreeFifthsCouncil>`** matches the `AdminOrigin` shape used by every other pallet in this runtime.

**`RemapDelay = 7 * DAYS`** (604,800 blocks at 1s). The pallet mock uses 100 blocks, which is a test value. 7 days matches `CooloffPeriod` and gives an account owner a week to notice a forced remap before it executes.

**`MaxAdjustmentFactor = 10`.** `AdjustmentFactor` reads `pallet_transaction_payment::NextFeeMultiplier`, and this runtime sets `MaximumMultiplier: Multiplier = Bounded::max_value()`, so without a finite cap the value feeding the base-fee formula is unbounded. 10x the `MinimumMultiplier` is a defensive ceiling, not a tuning knob.

## Pallet tests

`pallet-dynamic-evm-base-fee`'s mock could not compile either, and not only from the audit commit: it had also drifted from the vendored polkadot-sdk, missing six `frame_system` associated types and still setting `pallet_balances::MaxHolds`, which is now `DoneSlashHandler`. That dates to the stable2407 upgrade.

The cap had no test. There is one now: it drives `MaxAdjustmentFactor` low enough that the ideal base fee lands below the current one, so a capped and an uncapped run move the fee in opposite directions. The cap is storage-backed in the mock and defaults to `max_value`, so every pre-existing test still exercises the uncapped formula.

## Verification

- `cargo check -p selendra-runtime` clean. That is the exact crate CI died on.
- `cargo test -p pallet-dynamic-evm-base-fee` 14/14, including the new test.
- `cargo check --workspace` does not complete locally: `librocksdb-sys 0.11.0+8.1.1` fails its C++ build under GCC 16, missing `#include <cstdint>`. Environmental, not repo code, and CI's `ci-linux` image compiled it fine on the last run. The end-to-end proof is the Docker build that fires when this merges.

## Not fixed here

`bin/runtime/src/evm/mod.rs` sets `type WeightFactor = ();`, and `impl Get<u128> for ()` returns 0. The formula is `adjustment * WeightFactor * 25 / 98974`, so `ideal_new_bfpg` is always 0 and the EVM base fee is driven to `MinBaseFeePerGas` every block regardless of load. The pallet's own mock uses `30_000_000_000_000_000`. This looks wrong, but correcting it moves live EVM gas pricing, so it is a separate decision and a separate PR.

`spec_version` stays at 20016. That version is on `master` but was never built or deployed, so it still covers these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgmX87HE6r3UyxCQJp9rQ2